### PR TITLE
employee-management

### DIFF
--- a/src/main/java/com/example/employeemanagementsystem/controller/EmployeeController.java
+++ b/src/main/java/com/example/employeemanagementsystem/controller/EmployeeController.java
@@ -1,0 +1,51 @@
+package com.example.employeemanagementsystem.controller;
+
+import com.example.employeemanagementsystem.dto.ApiResponse;
+import com.example.employeemanagementsystem.dto.request.EmployeeRequest;
+import com.example.employeemanagementsystem.dto.response.EmployeeResponse;
+import com.example.employeemanagementsystem.dto.response.PageResponse;
+import com.example.employeemanagementsystem.service.EmployeeService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/employee")
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class EmployeeController {
+    EmployeeService employeeService;
+
+    @GetMapping
+    ApiResponse<PageResponse<EmployeeResponse>> findAll(
+            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
+            @RequestParam(value = "size", required = false, defaultValue = "10") int size) {
+        return ApiResponse.<PageResponse<EmployeeResponse>>builder()
+                .result(employeeService.findAll(page, size))
+                .build();
+    }
+
+    @GetMapping("/{employeeId}")
+    ApiResponse<EmployeeResponse> findById(@PathVariable Long employeeId) {
+        return ApiResponse.<EmployeeResponse>builder()
+                .result(employeeService.findById(employeeId))
+                .build();
+    }
+
+    @PutMapping("/update")
+    ApiResponse<EmployeeResponse> update(@RequestBody EmployeeRequest request) {
+        return ApiResponse.<EmployeeResponse>builder()
+                .result(employeeService.update(request))
+                .build();
+    }
+
+    @DeleteMapping("/delete/{employeeId}")
+    ApiResponse<Void> delete(@PathVariable Long employeeId) {
+        employeeService.delete(employeeId);
+        return ApiResponse.<Void>builder()
+                .result(null)
+                .message("Employee deleted successfully")
+                .build();
+    }
+}

--- a/src/main/java/com/example/employeemanagementsystem/dto/request/EmployeeRequest.java
+++ b/src/main/java/com/example/employeemanagementsystem/dto/request/EmployeeRequest.java
@@ -1,0 +1,26 @@
+package com.example.employeemanagementsystem.dto.request;
+
+import com.example.employeemanagementsystem.entity.Employee;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class EmployeeRequest {
+    Long employeeId;
+    String firstName;
+    String lastName;
+    Employee.Gender gender;
+    String email;
+    String phone;
+    String address;
+    LocalDate dateOfBirth;
+    String avatarUrl;
+    Boolean status;
+    Long departmentId;
+}

--- a/src/main/java/com/example/employeemanagementsystem/dto/request/RegisterRequest.java
+++ b/src/main/java/com/example/employeemanagementsystem/dto/request/RegisterRequest.java
@@ -21,4 +21,5 @@ public class RegisterRequest {
     String address;
     LocalDate dateOfBirth;
     Employee.Gender gender;
+    Long departmentId;
 }

--- a/src/main/java/com/example/employeemanagementsystem/dto/response/EmployeeResponse.java
+++ b/src/main/java/com/example/employeemanagementsystem/dto/response/EmployeeResponse.java
@@ -1,0 +1,28 @@
+package com.example.employeemanagementsystem.dto.response;
+
+import com.example.employeemanagementsystem.entity.Employee;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class EmployeeResponse {
+    Long employeeId;
+    String firstName;
+    String lastName;
+    Employee.Gender gender;
+    String email;
+    String phone;
+    String address;
+    LocalDate dateOfBirth;
+    String avatarUrl;
+    LocalDate createdAt;
+    LocalDate updatedAt;
+    Boolean status;
+    String departmentName;
+}

--- a/src/main/java/com/example/employeemanagementsystem/dto/response/PageResponse.java
+++ b/src/main/java/com/example/employeemanagementsystem/dto/response/PageResponse.java
@@ -1,0 +1,22 @@
+package com.example.employeemanagementsystem.dto.response;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.Collections;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class PageResponse<T> {
+    int currentPage;
+    int totalPages;
+    long totalElements;
+    int pageSize;
+
+    @Builder.Default
+    private List<T> data = Collections.emptyList();
+}

--- a/src/main/java/com/example/employeemanagementsystem/entity/Account.java
+++ b/src/main/java/com/example/employeemanagementsystem/entity/Account.java
@@ -24,7 +24,7 @@ public class Account {
     private String password; // Mã hóa bằng BCrypt
 
     @OneToOne
-    @JoinColumn(name = "employee_id")
+    @JoinColumn(name = "employee_id", nullable = false, unique = true)
     private Employee employee;
 
     @ManyToOne

--- a/src/main/java/com/example/employeemanagementsystem/entity/Department.java
+++ b/src/main/java/com/example/employeemanagementsystem/entity/Department.java
@@ -19,8 +19,8 @@ public class Department {
     @Column(name = "department_id")
     private Long departmentId;
 
-    @Column(nullable = false)
-    private String name;
+    @Column(name = "department_name", nullable = false)
+    private String departmentName;
 
     private String description;
 

--- a/src/main/java/com/example/employeemanagementsystem/entity/Employee.java
+++ b/src/main/java/com/example/employeemanagementsystem/entity/Employee.java
@@ -6,6 +6,7 @@ import lombok.*;
 import jakarta.validation.constraints.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "employees")
@@ -55,8 +56,28 @@ public class Employee {
     @JoinColumn(name = "department_id")
     private Department department;
 
+    @OneToOne(mappedBy = "employee", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private Account account;
+
     @Column(nullable = false)
     private Boolean status;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
 
     public enum Gender {
         MALE, FEMALE, OTHER

--- a/src/main/java/com/example/employeemanagementsystem/exception/ErrorCode.java
+++ b/src/main/java/com/example/employeemanagementsystem/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(1004, "Password must be at least {min} characters", HttpStatusCode.valueOf(400)),
     USER_NOT_EXISTED(1005, "User not existed", HttpStatusCode.valueOf(404)),
     UNAUTHENTICATED(1006, "Unauthenticated", HttpStatusCode.valueOf(401)),
+    VALIDATION_ERROR(1008, "Validation error", HttpStatusCode.valueOf(400)),
     UNAUTHORIZED(1007, "You do not have permission", HttpStatusCode.valueOf(403));
 
     ErrorCode(int code, String message, HttpStatusCode statusCode) {

--- a/src/main/java/com/example/employeemanagementsystem/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/employeemanagementsystem/exception/GlobalExceptionHandler.java
@@ -1,42 +1,89 @@
 package com.example.employeemanagementsystem.exception;
 
 import com.example.employeemanagementsystem.dto.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.util.stream.Collectors;
+
+@Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
-    @ExceptionHandler(value = Exception.class)
-    ResponseEntity<ApiResponse> handlingRuntimeException(RuntimeException exception) {
-        ApiResponse apiResponse = new ApiResponse();
 
-        apiResponse.setCode(ErrorCode.UNCATEGORIZED_EXCEPTION.getCode());
-        apiResponse.setMessage(ErrorCode.UNCATEGORIZED_EXCEPTION.getMessage());
+    // Bắt lỗi chung chung
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse> handleGeneralException(Exception exception) {
+        log.error("Unhandled exception: ", exception);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .code(ErrorCode.UNCATEGORIZED_EXCEPTION.getCode())
+                .message(ErrorCode.UNCATEGORIZED_EXCEPTION.getMessage())
+                .build();
 
         return ResponseEntity.badRequest().body(apiResponse);
     }
 
-    @ExceptionHandler(value = AppException.class)
-    public ResponseEntity<ApiResponse> handlingAppException(AppException exception) {
-        ErrorCode errorCode = exception.getErrorCode();
-        ApiResponse apiResponse = new ApiResponse();
+    // Bắt lỗi runtime
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ApiResponse> handleRuntimeException(RuntimeException exception) {
+        log.error("Runtime exception: ", exception);
 
-        apiResponse.setCode(errorCode.getCode());
-        apiResponse.setMessage(errorCode.getMessage());
+        ApiResponse apiResponse = ApiResponse.builder()
+                .code(ErrorCode.UNCATEGORIZED_EXCEPTION.getCode())
+                .message(ErrorCode.UNCATEGORIZED_EXCEPTION.getMessage())
+                .build();
+
+        return ResponseEntity.badRequest().body(apiResponse);
+    }
+
+    // Bắt lỗi do ứng dụng custom
+    @ExceptionHandler(AppException.class)
+    public ResponseEntity<ApiResponse> handleAppException(AppException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
+
+        log.warn("App exception: {}", errorCode);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
 
         return ResponseEntity.status(errorCode.getStatusCode()).body(apiResponse);
     }
 
-    @ExceptionHandler(value = AccessDeniedException.class)
-    public ResponseEntity<ApiResponse> handlingAccessDeniedException(AccessDeniedException exception) {
+    // Bắt lỗi phân quyền
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse> handleAccessDeniedException(AccessDeniedException exception) {
         ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
 
-        return ResponseEntity.status(errorCode.getStatusCode())
-                .body(ApiResponse.builder()
-                        .code(errorCode.getCode())
-                        .message(errorCode.getMessage())
-                        .build());
+        log.warn("Access denied: {}", exception.getMessage());
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
+
+        return ResponseEntity.status(errorCode.getStatusCode()).body(apiResponse);
+    }
+
+    // Bắt lỗi validate đầu vào (thường dùng với @Valid)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        String errorMessage = ex.getBindingResult().getAllErrors().stream()
+                .map(error -> error.getDefaultMessage())
+                .collect(Collectors.joining("; "));
+
+        log.info("Validation failed: {}", errorMessage);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .code(ErrorCode.VALIDATION_ERROR.getCode())
+                .message(errorMessage)
+                .build();
+
+        return ResponseEntity.badRequest().body(apiResponse);
     }
 }

--- a/src/main/java/com/example/employeemanagementsystem/mapper/EmployeeMapper.java
+++ b/src/main/java/com/example/employeemanagementsystem/mapper/EmployeeMapper.java
@@ -1,10 +1,19 @@
 package com.example.employeemanagementsystem.mapper;
 
+import com.example.employeemanagementsystem.dto.request.EmployeeRequest;
 import com.example.employeemanagementsystem.dto.request.RegisterRequest;
+import com.example.employeemanagementsystem.dto.response.EmployeeResponse;
 import com.example.employeemanagementsystem.entity.Employee;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 @Mapper(componentModel = "spring")
 public interface EmployeeMapper {
     Employee toEmployee(RegisterRequest registerRequest);
+
+    @Mapping(target = "departmentName", source = "department.departmentName")
+    EmployeeResponse toEmployeeResponse(Employee employee);
+
+    void requestToEmployee(@MappingTarget Employee employee, EmployeeRequest employeeRequest);
 }

--- a/src/main/java/com/example/employeemanagementsystem/security/CustomJwtDecoder.java
+++ b/src/main/java/com/example/employeemanagementsystem/security/CustomJwtDecoder.java
@@ -1,49 +1,29 @@
 package com.example.employeemanagementsystem.security;
 
-import com.example.employeemanagementsystem.dto.request.IntrospectRequest;
-import com.example.employeemanagementsystem.service.AuthenticationService;
-import com.nimbusds.jose.JOSEException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import java.text.ParseException;
+
+import com.nimbusds.jwt.SignedJWT;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtException;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.stereotype.Component;
-
-import javax.crypto.spec.SecretKeySpec;
-import java.text.ParseException;
-import java.util.Objects;
 
 @Component
 public class CustomJwtDecoder implements JwtDecoder {
-    @Value("${jwt.signerKey}")
-    private String signerKey;
-
-    @Autowired
-    private AuthenticationService authenticationService;
-
-    private NimbusJwtDecoder nimbusJwtDecoder = null;
-
     @Override
     public Jwt decode(String token) throws JwtException {
         try {
-            var response = authenticationService.introspect(
-                    IntrospectRequest.builder().token(token).build());
+            SignedJWT signedJWT = SignedJWT.parse(token);
 
-            if (!response.isValid()) throw new JwtException("Token invalid");
-        } catch (JwtException | ParseException | JOSEException e) {
-            throw new JwtException(e.getMessage());
+            return new Jwt(
+                    token,
+                    signedJWT.getJWTClaimsSet().getIssueTime().toInstant(),
+                    signedJWT.getJWTClaimsSet().getExpirationTime().toInstant(),
+                    signedJWT.getHeader().toJSONObject(),
+                    signedJWT.getJWTClaimsSet().getClaims()
+            );
+        } catch (ParseException e) {
+            throw new JwtException("Invalid token");
         }
-
-        if (Objects.isNull(nimbusJwtDecoder)) {
-            SecretKeySpec secretKeySpec = new SecretKeySpec(signerKey.getBytes(), "HS512");
-            nimbusJwtDecoder = NimbusJwtDecoder.withSecretKey(secretKeySpec)
-                    .macAlgorithm(MacAlgorithm.HS512)
-                    .build();
-        }
-
-        return nimbusJwtDecoder.decode(token);
     }
 }

--- a/src/main/java/com/example/employeemanagementsystem/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/employeemanagementsystem/security/JwtAuthenticationEntryPoint.java
@@ -1,19 +1,22 @@
 package com.example.employeemanagementsystem.security;
 
+import java.io.IOException;
+
 import com.example.employeemanagementsystem.dto.ApiResponse;
 import com.example.employeemanagementsystem.exception.ErrorCode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
-import java.io.IOException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+    public void commence(
+            HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException {
         ErrorCode errorCode = ErrorCode.UNAUTHENTICATED;
 
         response.setStatus(errorCode.getStatusCode().value());

--- a/src/main/java/com/example/employeemanagementsystem/service/AccountService.java
+++ b/src/main/java/com/example/employeemanagementsystem/service/AccountService.java
@@ -3,6 +3,7 @@ package com.example.employeemanagementsystem.service;
 import com.example.employeemanagementsystem.dto.request.RegisterRequest;
 import com.example.employeemanagementsystem.dto.response.RegisterResponse;
 import com.example.employeemanagementsystem.entity.Account;
+import com.example.employeemanagementsystem.entity.Department;
 import com.example.employeemanagementsystem.entity.Employee;
 import com.example.employeemanagementsystem.entity.Role;
 import com.example.employeemanagementsystem.exception.AppException;
@@ -10,6 +11,7 @@ import com.example.employeemanagementsystem.exception.ErrorCode;
 import com.example.employeemanagementsystem.mapper.AccountMapper;
 import com.example.employeemanagementsystem.mapper.EmployeeMapper;
 import com.example.employeemanagementsystem.repository.AccountRepository;
+import com.example.employeemanagementsystem.repository.DepartmentRepository;
 import com.example.employeemanagementsystem.repository.EmployeeRepository;
 import com.example.employeemanagementsystem.repository.RoleRepository;
 import lombok.AccessLevel;
@@ -27,6 +29,7 @@ public class AccountService {
     AccountRepository accountRepository;
     EmployeeRepository employeeRepository;
     RoleRepository roleRepository;
+    DepartmentRepository departmentRepository;
     AccountMapper accountMapper;
     EmployeeMapper employeeMapper;
     PasswordEncoder passwordEncoder;
@@ -36,7 +39,10 @@ public class AccountService {
             throw new AppException(ErrorCode.USER_EXISTED);
         }
 
+        Department department = departmentRepository.findById(request.getDepartmentId()).get();
+
         Employee employee = employeeMapper.toEmployee(request);
+        employee.setDepartment(department);
         employee.setStatus(true);
         employeeRepository.save(employee);
 

--- a/src/main/java/com/example/employeemanagementsystem/service/EmployeeService.java
+++ b/src/main/java/com/example/employeemanagementsystem/service/EmployeeService.java
@@ -1,0 +1,76 @@
+package com.example.employeemanagementsystem.service;
+
+import com.example.employeemanagementsystem.dto.request.EmployeeRequest;
+import com.example.employeemanagementsystem.dto.response.EmployeeResponse;
+import com.example.employeemanagementsystem.dto.response.PageResponse;
+import com.example.employeemanagementsystem.entity.Department;
+import com.example.employeemanagementsystem.entity.Employee;
+import com.example.employeemanagementsystem.exception.AppException;
+import com.example.employeemanagementsystem.exception.ErrorCode;
+import com.example.employeemanagementsystem.mapper.EmployeeMapper;
+import com.example.employeemanagementsystem.repository.AccountRepository;
+import com.example.employeemanagementsystem.repository.DepartmentRepository;
+import com.example.employeemanagementsystem.repository.EmployeeRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+public class EmployeeService {
+    EmployeeRepository employeeRepository;
+    DepartmentRepository departmentRepository;
+    AccountRepository accountRepository;
+    EmployeeMapper employeeMapper;
+
+    @PreAuthorize("hasRole('ADMIN')")
+    public PageResponse<EmployeeResponse> findAll(int page, int size) {
+        Sort sort = Sort.by("createdAt").descending();
+        Pageable pageable = PageRequest.of(page - 1, size, sort);
+
+        var employeePage = employeeRepository.findAll(pageable);
+
+        var pageList = employeePage.getContent()
+                .stream()
+                .map(employeeMapper::toEmployeeResponse)
+                .toList();
+
+        return PageResponse.<EmployeeResponse>builder()
+                .currentPage(page)
+                .pageSize(employeePage.getSize())
+                .totalPages(employeePage.getTotalPages())
+                .totalElements(employeePage.getTotalElements())
+                .data(pageList)
+                .build();
+    }
+
+    public EmployeeResponse findById(Long id) {
+        return employeeMapper.toEmployeeResponse(employeeRepository.findById(id).orElseThrow());
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    public EmployeeResponse update(EmployeeRequest request) {
+        Employee employee = employeeRepository.findById(request.getEmployeeId()).orElseThrow(() -> new AppException(ErrorCode.USER_NOT_EXISTED));
+        employeeMapper.requestToEmployee(employee, request);
+        employee.setEmployeeId(request.getEmployeeId());
+
+        Department department = departmentRepository.findById(request.getDepartmentId()).get();
+        employee.setDepartment(department);
+
+        return employeeMapper.toEmployeeResponse(employeeRepository.save(employee));
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    public void delete(Long id) {
+        Employee employee = employeeRepository.findById(id)
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_EXISTED));
+
+        employeeRepository.delete(employee);
+    }
+}


### PR DESCRIPTION
Summary
Add new EmployeeController with basic CRUD APIs including:

Get list of employees with pagination (GET /api/v1/employee)

Get employee details by ID (GET /api/v1/employee/{employeeId})

Update employee information (PUT /api/v1/employee/update)

Delete employee by ID (DELETE /api/v1/employee/delete/{employeeId})

Add EmployeeService to handle employee-related operations, ensuring that only admins are authorized to perform update and delete functions.

Create DTO EmployeeRequest and EmployeeResponse to separate input and return data, optimizing data structure.

Add PageResponse<T> generic to support returning standard pagination data.

Extend Entity Employee with createdAt, updatedAt fields to automatically update creation date, modification date.

Update Mapper EmployeeMapper supports mapping between Entity and DTO with exact field name mapping configuration.